### PR TITLE
Remove jupyter lab build step from binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,3 +1,1 @@
 pip install .
-
-jupyter-lab build --dev-build=False


### PR DESCRIPTION
This explicit step should not be necessary anymore now that the extension can be installed with `pip install`. 