### PR TITLE
Add voila to the Binder setup

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,11 @@ name: voila-editor
 channels:
 - conda-forge
 dependencies:
+- bqplot
+- ipympl
+- ipywidgets
 - python
 - nodejs
+- scipy
 - voila
 - voila-gridstack

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,5 +4,5 @@ channels:
 dependencies:
 - python
 - nodejs
-- mamba
-- jupyterlab
+- voila
+- voila-gridstack

--- a/jupyter_config.json
+++ b/jupyter_config.json
@@ -1,0 +1,6 @@
+{
+  "VoilaConfiguration": {
+    "enable_nbextensions": true,
+    "template": "gridstack"
+  }
+}


### PR DESCRIPTION
So the notebooks can also be rendered with the `/voila/render/` endpoint and the `voila-gridstack`template.