### PR TITLE
Bundle nested dirs in the wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ package_data_spec = {
 labext_name = "voila-editor"
 
 data_files_spec = [
-    ("share/jupyter/labextensions/%s" % labext_name, lab_path, "*.*"),
+    ("share/jupyter/labextensions/%s" % labext_name, lab_path, "**"),
 ]
 
 cmdclass = create_cmdclass("jsdeps",


### PR DESCRIPTION
Port of https://github.com/jupyterlab/extension-cookiecutter-ts/pull/105 to include directories like `schemas` when building the wheel.