### PR TITLE
New voila and voila editor buttons

### DIFF
--- a/examples/basics.ipynb
+++ b/examples/basics.ipynb
@@ -8,8 +8,8 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 0,
-        "height": 186,
+        "col": 1,
+        "height": 182,
         "hidden": false,
         "row": 1,
         "width": 5
@@ -33,25 +33,17 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 6,
-        "height": 99,
+        "col": 7,
+        "height": 116,
         "hidden": false,
-        "row": 296,
-        "width": 2
+        "row": 3,
+        "width": 1
        }
       }
      }
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"hello\")"
    ]
@@ -66,32 +58,16 @@
       "views": {
        "grid_default": {
         "col": 6,
-        "height": 184,
+        "height": 195,
         "hidden": false,
-        "row": 11,
-        "width": 2
+        "row": 219,
+        "width": 1
        }
       }
      }
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 -9\n",
-      "2 -8\n",
-      "3 -7\n",
-      "4 -6\n",
-      "5 -5\n",
-      "6 -4\n",
-      "7 -3\n",
-      "8 -2\n",
-      "9 -1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for i in [1,2,3,4,5,6,7,8,9]:\n",
     "    print(i, i-10)"
@@ -107,25 +83,16 @@
       "views": {
        "grid_default": {
         "col": 1,
-        "height": 205,
+        "height": 174,
         "hidden": false,
-        "row": 211,
+        "row": 243,
         "width": 3
        }
       }
      }
     }
    },
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (<ipython-input-6-8f1800b3a3be>, line 1)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-6-8f1800b3a3be>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    if :\u001b[0m\n\u001b[0m       ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if :\n",
     "    need error"

--- a/examples/test.ipynb
+++ b/examples/test.ipynb
@@ -43,15 +43,7 @@
      }
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"hello\")"
    ]
@@ -75,16 +67,7 @@
      }
     }
    },
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (<ipython-input-2-8f1800b3a3be>, line 1)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-2-8f1800b3a3be>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    if :\u001b[0m\n\u001b[0m       ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if :\n",
     "    need error"
@@ -99,11 +82,11 @@
       "version": 1,
       "views": {
        "grid_default": {
-        "col": 2,
-        "height": 1,
+        "col": 8,
+        "height": 4,
         "hidden": false,
-        "row": 30,
-        "width": 1
+        "row": 7,
+        "width": 2
        }
       }
      }

--- a/src/editor/components/notebookButtons.ts
+++ b/src/editor/components/notebookButtons.ts
@@ -1,0 +1,71 @@
+import { ToolbarButton } from '@jupyterlab/apputils';
+
+import { DocumentRegistry } from '@jupyterlab/docregistry';
+
+import { NotebookPanel, INotebookModel } from '@jupyterlab/notebook';
+
+import { PageConfig } from '@jupyterlab/coreutils';
+
+import { editIcon } from '@jupyterlab/ui-components';
+
+import { CommandRegistry } from '@lumino/commands';
+
+import { IDisposable } from '@lumino/disposable';
+
+const VOILA_ICON_CLASS = 'jp-MaterialIcon jp-VoilaIcon';
+
+export class EditorButton
+  implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
+  /**
+   * Instantiate a new NotebookButton.
+   * @param commands The command registry.
+   */
+  constructor(commands: CommandRegistry) {
+    this._commands = commands;
+  }
+
+  /**
+   * Create a new extension object.
+   */
+  createNew(panel: NotebookPanel): IDisposable {
+    const button = new ToolbarButton({
+      className: 'voilaEditor',
+      tooltip: 'Open with Voilà Editor',
+      icon: editIcon,
+      onClick: () => {
+        this._commands.execute('docmanager:open', {
+          path: panel.context.path,
+          factory: 'Voila Editor'
+        });
+      }
+    });
+    panel.toolbar.insertAfter('voila', 'voilaEditor', button);
+    return button;
+  }
+
+  private _commands: CommandRegistry;
+}
+
+export class VoilaButton
+  implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
+  /**
+   * Create a new extension object.
+   */
+  createNew(panel: NotebookPanel): IDisposable {
+    const button = new ToolbarButton({
+      className: 'voila',
+      tooltip: 'Render with Voilà',
+      iconClass: VOILA_ICON_CLASS,
+      onClick: () => {
+        const baseUrl = PageConfig.getBaseUrl();
+        const win = window.open(
+          `${baseUrl}voila/render/${panel.context.path}`,
+          '_blank'
+        );
+        win.focus();
+      }
+    });
+    panel.toolbar.insertAfter('cellType', 'voila', button);
+    return button;
+  }
+}

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -16,6 +16,8 @@ import VoilaWidgetFactory from './factory';
 
 import VoilaEditor from './widget';
 
+import { VoilaButton, EditorButton } from './components/notebookButtons';
+
 export const editor: JupyterFrontEndPlugin<void> = {
   id: 'voila-editor/editor',
   autoStart: true,
@@ -70,5 +72,11 @@ export const editor: JupyterFrontEndPlugin<void> = {
     });
 
     app.docRegistry.addWidgetFactory(factory);
+
+    app.docRegistry.addWidgetExtension('Notebook', new VoilaButton());
+    app.docRegistry.addWidgetExtension(
+      'Notebook',
+      new EditorButton(app.commands)
+    );
   }
 };

--- a/src/editor/toolbar/voila.tsx
+++ b/src/editor/toolbar/voila.tsx
@@ -1,0 +1,34 @@
+import { ReactWidget, ToolbarButtonComponent } from '@jupyterlab/apputils';
+
+import { PageConfig } from '@jupyterlab/coreutils';
+
+import * as React from 'react';
+
+export default class Voila extends ReactWidget {
+  constructor(path: string) {
+    super();
+    this._path = path;
+  }
+
+  render(): JSX.Element {
+    const onClick = (): void => {
+      const baseUrl = PageConfig.getBaseUrl();
+      const conf = '?voila-template=gridstack';
+      const win = window.open(
+        `${baseUrl}voila/render/${this._path + conf}`,
+        '_blank'
+      );
+      win.focus();
+    };
+
+    return (
+      <ToolbarButtonComponent
+        iconClass="jp-MaterialIcon jp-VoilaIcon"
+        onClick={onClick}
+        tooltip={'Open voila'}
+      />
+    );
+  }
+
+  private _path: string;
+}

--- a/src/editor/widget.ts
+++ b/src/editor/widget.ts
@@ -8,6 +8,8 @@ import EditorPanel from './panel';
 
 import Save from './toolbar/save';
 
+import Voila from './toolbar/voila';
+
 export default class VoilaEditor extends DocumentWidget<
   EditorPanel,
   INotebookModel
@@ -23,13 +25,11 @@ export default class VoilaEditor extends DocumentWidget<
     this.title.icon = listIcon;
 
     // Adding the buttons to the widget toolbar
-    this._save = new Save(this.content);
-    this.toolbar.addItem('save', this._save);
+    this.toolbar.addItem('save', new Save(this.content));
+    this.toolbar.addItem('voila', new Voila(this.context.path));
   }
 
   dispose(): void {
     super.dispose();
   }
-
-  private _save: Save;
 }

--- a/style/icons/voila-dark.svg
+++ b/style/icons/voila-dark.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="Calque_1"
+   data-name="Calque 1"
+   viewBox="0 0 330.005 330.005"
+   version="1.1"
+   sodipodi:docname="voila-dark.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   width="330.005"
+   height="330.005">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>BLEU-proposition-icone</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2426"
+     inkscape:window-height="1329"
+     id="namedview15"
+     showgrid="false"
+     inkscape:zoom="1.888"
+     inkscape:cx="97.210877"
+     inkscape:cy="202.16763"
+     inkscape:window-x="134"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Calque_1"
+     fit-margin-top="10"
+     fit-margin-left="10"
+     fit-margin-right="10"
+     fit-margin-bottom="10" />
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:#5dbcaf;}.cls-2{fill:#268380;}.cls-3{fill:#f8e14b;}</style>
+  </defs>
+  <title
+     id="title6">BLEU-proposition-icone</title>
+  <path
+     class="cls-2"
+     d="m 165.005,320 c -85.47,0 -155,-69.53 -155,-155 0,-85.47 69.53,-155 155,-155 85.47,0 155,69.53 155,155 0,85.47 -69.53,155 -155,155 z m 0,-275.49 A 120.49,120.49 0 1 0 285.495,165 120.62,120.62 0 0 0 165.005,44.51 Z"
+     id="path10"
+     style="fill:#bbbbbb;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     class="cls-3"
+     d="m 165.005,320 c -85.47,0 -155,-69.53 -155,-155 a 17.26,17.26 0 1 1 34.51,0 120.62,120.62 0 0 0 120.49,120.49 17.26,17.26 0 1 1 0,34.51 z"
+     id="path12"
+     inkscape:connector-curvature="0"
+     style="fill:#d97d24;fill-opacity:1" />
+</svg>

--- a/style/icons/voila-light.svg
+++ b/style/icons/voila-light.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="Calque_1"
+   data-name="Calque 1"
+   viewBox="0 0 330.005 330.005"
+   version="1.1"
+   sodipodi:docname="voila-light.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   width="330.005"
+   height="330.005">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>BLEU-proposition-icone</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2426"
+     inkscape:window-height="1329"
+     id="namedview15"
+     showgrid="false"
+     inkscape:zoom="1.888"
+     inkscape:cx="-252.89506"
+     inkscape:cy="180.98119"
+     inkscape:window-x="134"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Calque_1"
+     fit-margin-top="10"
+     fit-margin-left="10"
+     fit-margin-right="10"
+     fit-margin-bottom="10" />
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:#5dbcaf;}.cls-2{fill:#268380;}.cls-3{fill:#f8e14b;}</style>
+  </defs>
+  <title
+     id="title6">BLEU-proposition-icone</title>
+  <path
+     class="cls-2"
+     d="m 165.005,320 c -85.47,0 -155,-69.53 -155,-155 0,-85.47 69.53,-155 155,-155 85.47,0 155,69.53 155,155 0,85.47 -69.53,155 -155,155 z m 0,-275.49 A 120.49,120.49 0 1 0 285.495,165 120.62,120.62 0 0 0 165.005,44.51 Z"
+     id="path10"
+     style="fill:#616161;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     class="cls-3"
+     d="m 165.005,320 c -85.47,0 -155,-69.53 -155,-155 a 17.26,17.26 0 1 1 34.51,0 120.62,120.62 0 0 0 120.49,120.49 17.26,17.26 0 1 1 0,34.51 z"
+     id="path12"
+     inkscape:connector-curvature="0"
+     style="fill:#f8e14b" />
+</svg>

--- a/style/icons/voila.svg
+++ b/style/icons/voila.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="Calque_1"
+   data-name="Calque 1"
+   viewBox="0 0 330.005 330.005"
+   version="1.1"
+   sodipodi:docname="voila.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   width="330.005"
+   height="330.005">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>BLEU-proposition-icone</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1011"
+     inkscape:window-height="492"
+     id="namedview15"
+     showgrid="false"
+     inkscape:zoom="0.472"
+     inkscape:cx="165.005"
+     inkscape:cy="165.005"
+     inkscape:window-x="134"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Calque_1"
+     fit-margin-top="10"
+     fit-margin-left="10"
+     fit-margin-right="10"
+     fit-margin-bottom="10" />
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:#5dbcaf;}.cls-2{fill:#268380;}.cls-3{fill:#f8e14b;}</style>
+  </defs>
+  <title
+     id="title6">BLEU-proposition-icone</title>
+  <path
+     class="cls-2"
+     d="m 165.005,320 c -85.47,0 -155,-69.53 -155,-155 0,-85.47 69.53,-155 155,-155 85.47,0 155,69.53 155,155 0,85.47 -69.53,155 -155,155 z m 0,-275.49 A 120.49,120.49 0 1 0 285.495,165 120.62,120.62 0 0 0 165.005,44.51 Z"
+     id="path10"
+     inkscape:connector-curvature="0"
+     style="fill:#268380" />
+  <path
+     class="cls-3"
+     d="m 165.005,320 c -85.47,0 -155,-69.53 -155,-155 a 17.26,17.26 0 1 1 34.51,0 120.62,120.62 0 0 0 120.49,120.49 17.26,17.26 0 1 1 0,34.51 z"
+     id="path12"
+     inkscape:connector-curvature="0"
+     style="fill:#f8e14b" />
+</svg>

--- a/style/index.css
+++ b/style/index.css
@@ -1,3 +1,5 @@
+@import 'variables.css';
+
 .grid-editor {
   padding: 2px;
   overflow: scroll;
@@ -31,4 +33,12 @@
   color: var(--jp-ui-font-color0);
   background-color: var(--jp-layout-color2);
   box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
+}
+
+.jp-VoilaIcon {
+  background-image: var(--jp-icon-voila);
+}
+
+.jp-VoilaPreview-renderOnSave {
+  align-items: center;
 }

--- a/style/variables.css
+++ b/style/variables.css
@@ -1,0 +1,7 @@
+[data-jp-theme-light='true'] {
+  --jp-icon-voila: url('./icons/voila-light.svg');
+}
+
+[data-jp-theme-light='false'] {
+  --jp-icon-voila: url('./icons/voila-dark.svg');
+}


### PR DESCRIPTION
Added two buttons in the Notebook toolbar to open the notebook in Voila and in Voila Editor.
![Screenshot 2020-10-29 at 13 56 20](https://user-images.githubusercontent.com/26092748/97576655-b97fbf80-19ee-11eb-9aea-97d1b42502d7.png)

Added a button in the Voila Editor toolbar to open the notebook in Voila.
![Screenshot 2020-10-29 at 13 56 27](https://user-images.githubusercontent.com/26092748/97576729-d6b48e00-19ee-11eb-869f-4c8315b89ce1.png)
