### PR TITLE
Editor plugin provides a tracker for editors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
     '@typescript-eslint/quotes': [
       'error',

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "@jupyterlab/filebrowser": "^3.0.0-rc.5",
     "@jupyterlab/notebook": "^3.0.0-rc.5",
     "@jupyterlab/ui-components": "^3.0.0-rc.5",
+    "@jupyter-widgets/base": "^3.0.0-alpha.2",
     "@jupyter-widgets/jupyterlab-manager": "^3.0.0-alpha.2",
+    "@lumino/coreutils": "^1.5.3",
     "@lumino/widgets": "^1.14.0",
     "@types/codemirror": "^0.0.97",
     "gridstack": "^2.1.0",
@@ -89,6 +91,10 @@
     "schemaDir": "schema",
     "outputDir": "voila-editor/static",
     "sharedPackages": {
+      "@jupyter-widgets/base": {
+        "bundled": false,
+        "singleton": true
+      },
       "@jupyter-widgets/jupyterlab-manager": {
         "bundled": false,
         "singleton": true

--- a/src/editor/factory.ts
+++ b/src/editor/factory.ts
@@ -10,11 +10,11 @@ import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
-import VoilaEditor from './widget';
+import { VoilaEditor } from './widget';
 
-import EditorPanel from './panel';
+import { EditorPanel } from './panel';
 
-export default class VoilaWidgetFactory extends ABCWidgetFactory<
+export class VoilaWidgetFactory extends ABCWidgetFactory<
   VoilaEditor,
   INotebookModel
 > {

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -12,15 +12,16 @@ import { IEditorServices } from '@jupyterlab/codeeditor';
 
 import { WidgetTracker } from '@jupyterlab/apputils';
 
-import VoilaWidgetFactory from './factory';
+import { VoilaWidgetFactory } from './factory';
 
-import VoilaEditor from './widget';
+import { IVoilaEditorTracker, VoilaEditor } from './widget';
 
 import { VoilaButton, EditorButton } from './components/notebookButtons';
 
-export const editor: JupyterFrontEndPlugin<void> = {
+export const editor: JupyterFrontEndPlugin<IVoilaEditorTracker> = {
   id: 'voila-editor/editor',
   autoStart: true,
+  provides: IVoilaEditorTracker,
   optional: [],
   requires: [
     ILayoutRestorer,
@@ -78,5 +79,7 @@ export const editor: JupyterFrontEndPlugin<void> = {
       'Notebook',
       new EditorButton(app.commands)
     );
+
+    return tracker;
   }
 };

--- a/src/editor/panel.ts
+++ b/src/editor/panel.ts
@@ -34,7 +34,7 @@ import { GridItem, DashboardCellView } from './components/gridItem';
 
 import EditorGridstack from './components/editorGridstack';
 
-export default class EditorPanel extends SplitPanel {
+export class EditorPanel extends SplitPanel {
   constructor(options: EditorPanel.IOptions) {
     super();
     this.addClass('grid-panel');

--- a/src/editor/toolbar/edit.tsx
+++ b/src/editor/toolbar/edit.tsx
@@ -4,7 +4,7 @@ import { editIcon } from '@jupyterlab/ui-components';
 
 import * as React from 'react';
 
-import EditorPanel from '../panel';
+import { EditorPanel } from '../panel';
 
 export default class Edit extends ReactWidget {
   constructor(panel: EditorPanel) {

--- a/src/editor/toolbar/save.tsx
+++ b/src/editor/toolbar/save.tsx
@@ -4,7 +4,7 @@ import { saveIcon } from '@jupyterlab/ui-components';
 
 import * as React from 'react';
 
-import EditorPanel from '../panel';
+import { EditorPanel } from '../panel';
 
 export default class Save extends ReactWidget {
   constructor(panel: EditorPanel) {

--- a/src/editor/widget.ts
+++ b/src/editor/widget.ts
@@ -1,10 +1,14 @@
+import { IWidgetTracker } from '@jupyterlab/apputils';
+
 import { DocumentWidget, DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { INotebookModel } from '@jupyterlab/notebook';
 
 import { listIcon } from '@jupyterlab/ui-components';
 
-import EditorPanel from './panel';
+import { Token } from '@lumino/coreutils';
+
+import { EditorPanel } from './panel';
 
 import Save from './toolbar/save';
 
@@ -12,10 +16,7 @@ import Edit from './toolbar/edit';
 
 import Voila from './toolbar/voila';
 
-export default class VoilaEditor extends DocumentWidget<
-  EditorPanel,
-  INotebookModel
-> {
+export class VoilaEditor extends DocumentWidget<EditorPanel, INotebookModel> {
   constructor(
     context: DocumentRegistry.IContext<INotebookModel>,
     content: EditorPanel
@@ -36,3 +37,15 @@ export default class VoilaEditor extends DocumentWidget<
     super.dispose();
   }
 }
+
+/**
+ * A class that tracks Voila Editor widgets.
+ */
+export interface IVoilaEditorTracker extends IWidgetTracker<VoilaEditor> {}
+
+/**
+ * The Voila Editor tracker token.
+ */
+export const IVoilaEditorTracker = new Token<IVoilaEditorTracker>(
+  'voila-editor:IVoilaEditorTracker'
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 
 import { editor } from './editor';
 
-const voilaEditor: JupyterFrontEndPlugin<any>[] = [editor];
+import { widgets } from './widgets';
 
-export default voilaEditor;
+const plugins: JupyterFrontEndPlugin<any>[] = [editor, widgets];
+
+export default plugins;

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -1,0 +1,21 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
+
+import { IVoilaEditorTracker } from '../editor/widget';
+
+export const widgets: JupyterFrontEndPlugin<void> = {
+  id: 'voila-editor/widgets',
+  autoStart: true,
+  optional: [IVoilaEditorTracker, IJupyterWidgetRegistry],
+  activate: (
+    app: JupyterFrontEnd,
+    voilaEditorTracker: IVoilaEditorTracker | null,
+    widgeRegistry: IJupyterWidgetRegistry | null
+  ) => {
+    console.log(widgets.id, 'activated');
+  }
+};


### PR DESCRIPTION
Fixes #49.

Also add a placeholder plugin for widgets that consumes `IVoilaEditorTracker` (https://github.com/hbcarlos/voila-editor/issues/50)