### PR TITLE
Trigger resize events for bqplot

### DIFF
--- a/packages/jupyterlab-gridstack/src/editor/gridstack/gridstackItemWidget.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/gridstackItemWidget.ts
@@ -4,13 +4,11 @@ import { Widget } from '@lumino/widgets';
  * A Lumino widget for gridstack items.
  */
 export class GridStackItem extends Widget {
-  constructor(cellId: string, widget: HTMLElement, close: HTMLElement) {
+  constructor(cellId: string, item: Widget, close: HTMLElement) {
     super();
     this.removeClass('lm-Widget');
     this.removeClass('p-Widget');
     this.addClass('grid-stack-item');
-
-    this.cellId = cellId;
 
     const content = document.createElement('div');
     content.className = 'grid-stack-item-content';
@@ -18,11 +16,28 @@ export class GridStackItem extends Widget {
     const toolbar = document.createElement('div');
     toolbar.className = 'grid-item-toolbar';
 
+    const cell = document.createElement('div');
+    cell.className = 'grid-item-widget';
+    this._cell = cell;
+
+    this._item = item;
+    this._cellId = cellId;
+
     toolbar.appendChild(close);
     content.appendChild(toolbar);
-    content.appendChild(widget);
+    content.appendChild(cell);
     this.node.appendChild(content);
   }
 
-  cellId: string;
+  get cellId(): string {
+    return this._cellId;
+  }
+
+  onAfterAttach(): void {
+    Widget.attach(this._item, this._cell);
+  }
+
+  private _cell: HTMLElement;
+  private _item: Widget;
+  private _cellId = '';
 }

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/gridstackLayout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/gridstackLayout.ts
@@ -73,6 +73,10 @@ export class GridStackLayout extends Layout {
         }
       }
     );
+
+    this._grid.on('resizestop', (event, elem) => {
+      window.dispatchEvent(new Event('resize'));
+    });
   }
 
   get gridItemChanged(): ISignal<this, GridStackNode[]> {
@@ -93,6 +97,8 @@ export class GridStackLayout extends Layout {
   init(): void {
     super.init();
     this.parent!.node.appendChild(this._gridHost);
+    // fake window resize event to resize bqplot
+    window.dispatchEvent(new Event('resize'));
   }
 
   /**

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/gridstackLayout.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/gridstackLayout.ts
@@ -4,7 +4,7 @@ import { IIterator, ArrayIterator } from '@lumino/algorithm';
 
 import { Signal, ISignal } from '@lumino/signaling';
 
-import { Message } from '@lumino/messaging';
+import { Message, MessageLoop } from '@lumino/messaging';
 
 import {
   GridStack,
@@ -240,7 +240,10 @@ export class GridStackLayout extends Layout {
     }
 
     this._gridItems.push(item);
+
+    MessageLoop.sendMessage(item, Widget.Msg.BeforeAttach);
     this._grid.addWidget(item.node, options);
+    MessageLoop.sendMessage(item, Widget.Msg.AfterAttach);
   }
 
   /**

--- a/packages/jupyterlab-gridstack/src/editor/gridstack/gridstackModel.ts
+++ b/packages/jupyterlab-gridstack/src/editor/gridstack/gridstackModel.ts
@@ -24,6 +24,8 @@ import { SimplifiedOutputArea } from '@jupyterlab/outputarea';
 
 import { IObservableUndoableList } from '@jupyterlab/observables';
 
+import { Widget } from '@lumino/widgets';
+
 import { Signal, ISignal } from '@lumino/signaling';
 
 import { deleteIcon } from '../icons';
@@ -250,8 +252,7 @@ export class GridStackModel {
    * @param cellModel - `ICellModel`.
    */
   public createCell(cellModel: ICellModel): GridStackItem {
-    const cell = document.createElement('div');
-    cell.className = 'grid-item-widget';
+    let item: Widget;
 
     switch (cellModel.type) {
       case 'code': {
@@ -263,13 +264,12 @@ export class GridStackModel {
           updateEditorOnShow: true
         });
 
-        const item = new SimplifiedOutputArea({
+        item = new SimplifiedOutputArea({
           model: codeCell.outputArea.model,
           rendermime: codeCell.outputArea.rendermime,
           contentFactory: codeCell.outputArea.contentFactory
         });
 
-        cell.appendChild(item.node);
         break;
       }
       case 'markdown': {
@@ -284,7 +284,7 @@ export class GridStackModel {
         markdownCell.rendered = true;
         Private.removeElements(markdownCell.node, 'jp-Collapser');
         Private.removeElements(markdownCell.node, 'jp-InputPrompt');
-        cell.appendChild(markdownCell.node);
+        item = markdownCell;
         break;
       }
       default: {
@@ -297,7 +297,7 @@ export class GridStackModel {
         rawCell.inputHidden = false;
         Private.removeElements(rawCell.node, 'jp-Collapser');
         Private.removeElements(rawCell.node, 'jp-InputPrompt');
-        cell.appendChild(rawCell.node);
+        item = rawCell;
         break;
       }
     }
@@ -314,7 +314,7 @@ export class GridStackModel {
       this._cellRemoved.emit(cellModel.id);
     };
 
-    return new GridStackItem(cellModel.id, cell, close);
+    return new GridStackItem(cellModel.id, item, close);
   }
 
   /**


### PR DESCRIPTION
Trying to fix #69 

Opening this PR for visibility, although this doesn't seem to be enough for now.

The resize seems to correctly be caught by bqplot:

![resize-event](https://user-images.githubusercontent.com/591645/101930074-f4713780-3bd7-11eb-8408-5b64b0a39f0c.gif)

With sizes that look correct? (at least for width and height)

![image](https://user-images.githubusercontent.com/591645/101930056-ef13ed00-3bd7-11eb-9b0a-8e77c33993cd.png)

So this might require digging a bit more into bqplot to understand what is happening.
