### PR TITLE
Add archive note to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # jupyterlab-gridstack
 
+## Archived
+
+**This repository is archived. Development is now happening in https://github.com/voila-dashboards/voila-gridstack**.
+
+---
+
 ![Github Actions Status](https://github.com/hbcarlos/voila-editor/workflows/Build/badge.svg)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hbcarlos/voila-editor/master?urlpath=lab)
 
 A JupyterLab extension to create voila dashboards.


### PR DESCRIPTION
Now that the extension has been moved to https://github.com/voila-dashboards/voila-gridstack, we should be able to add a note to the readme and archive the repository.